### PR TITLE
Wb dnsdist

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,10 +13,11 @@ class dnsdist::config (
   $control_socket,
   $server_policy,
   $listen_addresses,
-  $number_of_cpus
+  $number_of_cpus,
+  $version
 ){
 
-  concat { "/etc/dnsdist/dnsdist.conf":
+  concat { '/etc/dnsdist/dnsdist.conf':
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
@@ -24,20 +25,20 @@ class dnsdist::config (
     require => [Package['dnsdist']]
   }
 
-  concat::fragment { "global-header":
-    target  => "/etc/dnsdist/dnsdist.conf",
+  concat::fragment { 'global-header':
+    target  => '/etc/dnsdist/dnsdist.conf',
     content => template('dnsdist/dnsdist.conf-header.erb'),
     order   => '10';
   }
 
-  concat::fragment { "acl-header":
-    target  => "/etc/dnsdist/dnsdist.conf",
+  concat::fragment { 'acl-header':
+    target  => '/etc/dnsdist/dnsdist.conf',
     content => 'setACL({',
     order   => '40';
   }
 
-  concat::fragment { "acl-footer":
-    target  => "/etc/dnsdist/dnsdist.conf",
+  concat::fragment { 'acl-footer':
+    target  => '/etc/dnsdist/dnsdist.conf',
     content => "})\n",
     order   => '49';
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class dnsdist (
     control_socket   => $control_socket,
     server_policy    => $server_policy,
     listen_addresses => $listen_addresses,
+    version          => $version
     number_of_cpus   => $number_of_cpus
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class dnsdist (
     control_socket   => $control_socket,
     server_policy    => $server_policy,
     listen_addresses => $listen_addresses,
-    version          => $version
+    version          => $version,
     number_of_cpus   => $number_of_cpus
   }
 

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -3,7 +3,7 @@ controlSocket("<%= @control_socket %>")
 setServerPolicy(<%= @server_policy %>)
 <% @number_of_cpus.to_i.times do | i |-%>
 <% @listen_addresses.each do |listen_address| -%>
-<%  if @version == 10-%>
+<%  if @version == 10 -%>
 addLocal("<%= listen_address %>:53",true,true)
 <% else -%>
 addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -3,10 +3,10 @@ controlSocket("<%= @control_socket %>")
 setServerPolicy(<%= @server_policy %>)
 <% @number_of_cpus.to_i.times do | i |-%>
 <% @listen_addresses.each do |listen_address| -%>
-<%  if @version == 10 -%>
-addLocal("<%= listen_address %>:53",true,true)
-<% else -%>
+<%  if @version == 12 -%>
 addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })
+<% else -%>
+addLocal("<%= listen_address %>:53",true,true)
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -2,11 +2,11 @@ webserver("<%= @webserver %>", "<%= @webserver_pass %>")
 controlSocket("<%= @control_socket %>")
 setServerPolicy(<%= @server_policy %>)
 <% @number_of_cpus.to_i.times do | i |-%>
-<% @listen_addresses.each do |listen_address| 
-  if @version == '10' 
-  -%>addLocal("<%= listen_address %>:53",true,true)
+<% @listen_addresses.each do |listen_address| -%>
+<%  if @version == '10'  -%>
+addLocal("<%= listen_address %>:53",true,true)
 <% else -%>
-  -%>addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })
+addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -3,6 +3,10 @@ controlSocket("<%= @control_socket %>")
 setServerPolicy(<%= @server_policy %>)
 <% @number_of_cpus.to_i.times do | i |-%>
 <% @listen_addresses.each do |listen_address| 
+  if @version == '10' 
   -%>addLocal("<%= listen_address %>:53",true,true)
+<% else -%>
+  -%>addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })
+<% end -%>
 <% end -%>
 <% end -%>

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -3,7 +3,7 @@ controlSocket("<%= @control_socket %>")
 setServerPolicy(<%= @server_policy %>)
 <% @number_of_cpus.to_i.times do | i |-%>
 <% @listen_addresses.each do |listen_address| -%>
-<%  if @version == '10'  -%>
+<%  if @version == 10-%>
 addLocal("<%= listen_address %>:53",true,true)
 <% else -%>
 addLocal("<%= listen_address %>:53",{ doTCP=true, reusePort=true })


### PR DESCRIPTION
Cater for dnsdist versions 1.1 and 1.2
To do that, I had to pass the version on to the config manifest so that it can make a decision based on it.
Also, some lint fixes regarding quotes.